### PR TITLE
Feature/testing albumview header

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,9 @@
+const { defineConfig } = require("cypress");
+
+module.exports = defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/cypress/e2e/header-spec.cy.js
+++ b/cypress/e2e/header-spec.cy.js
@@ -1,0 +1,23 @@
+describe('Header testing', () => {
+  beforeEach(() => {
+    cy.intercept("GET", "https://tune-spoon-db-v1.herokuapp.com/albums", {fixture: "albums.json"})
+    cy.visit('http://localhost:3000/')    
+  })
+
+  it('should have a title', () => {
+    cy.contains('Tune Spoon')
+  })
+
+  it('should send the user to the favorites page when favorites is clicked', () => {
+    cy.get('button').contains('Favorites')
+      .click()
+      .url().should('include', '/favorites')
+  })
+
+  it('should send the user to the home page when home is clicked', () => {
+    cy.visit('http://localhost:3000/27')
+    cy.get('button').contains('Home')
+      .click()
+      .url().should('include', '/')
+  })
+})

--- a/cypress/e2e/home-page-spec.cy.js
+++ b/cypress/e2e/home-page-spec.cy.js
@@ -1,0 +1,17 @@
+describe('Home page testing', () => {
+  beforeEach(() => {
+    cy.intercept("GET", "https://tune-spoon-db-v1.herokuapp.com/albums", {fixture: "albums.json"})
+    cy.visit('http://localhost:3000/')    
+  })
+
+  it('should display a list of albums', () => {
+    cy.get('img[alt="Unlimited Love"]')
+      .should('have.attr', 'src', 'https://lastfm.freetls.fastly.net/i/u/770x0/07f19170333eb7221e6486b32d39da49.jpg#07f19170333eb7221e6486b32d39da49')
+    
+    cy.get('img[alt="No New World"]')
+      .should('have.attr', 'src', 'https://lastfm.freetls.fastly.net/i/u/770x0/088fea2b4baa6f4ee55d9925a4aa9d8f.jpg#088fea2b4baa6f4ee55d9925a4aa9d8f')
+
+    cy.get('img[alt="Brothers in Arms"]')
+      .should('have.attr', 'src', 'https://lastfm.freetls.fastly.net/i/u/770x0/d3394952d369468ec64a7d5582c013cc.jpg#d3394952d369468ec64a7d5582c013cc')
+  })
+})

--- a/cypress/e2e/home-page-spec.cy.js
+++ b/cypress/e2e/home-page-spec.cy.js
@@ -14,4 +14,10 @@ describe('Home page testing', () => {
     cy.get('img[alt="Brothers in Arms"]')
       .should('have.attr', 'src', 'https://lastfm.freetls.fastly.net/i/u/770x0/d3394952d369468ec64a7d5582c013cc.jpg#d3394952d369468ec64a7d5582c013cc')
   })
+
+  it('should redirect the user to the single albums page when clicked', () => {
+    cy.get('img[alt="WLFGRL"]')
+      .click()
+      .url().should('include', '/22')
+  })
 })

--- a/cypress/fixtures/albums.json
+++ b/cypress/fixtures/albums.json
@@ -1,0 +1,362 @@
+[
+  {
+      "id": 1,
+      "title": "Desire, I Want to Turn Into You",
+      "artist": "Caroline Polachek",
+      "image": "https://www.last.fm/music/Caroline+Polachek/Desire,+I+Want+to+Turn+Into+You/+images/97ae5e7ade492179bec606df66c41f35",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 2,
+      "title": "Sun Machine",
+      "artist": "Rubblebucket",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/c0b4a053cd548b420ba984a8caf84eb3.jpg#c0b4a053cd548b420ba984a8caf84eb3",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 3,
+      "title": "Unlimited Love",
+      "artist": "Red Hot Chili Peppers",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/07f19170333eb7221e6486b32d39da49.jpg#07f19170333eb7221e6486b32d39da49",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 4,
+      "title": "SOS",
+      "artist": "SZA",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/b2cfb5bdf137f4d6293565205965750f.jpg#b2cfb5bdf137f4d6293565205965750f",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 5,
+      "title": "Earth Worship",
+      "artist": "Rubblebucket",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/5511ebd31c06a2baa22e56d4b79ecd12.jpg#5511ebd31c06a2baa22e56d4b79ecd12",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 6,
+      "title": "Choose Your Weapon",
+      "artist": "Hiatus Kaiyote",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/648cd00cee4d489a04a190aa20112a4f.jpg#648cd00cee4d489a04a190aa20112a4f",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 7,
+      "title": "Drunk",
+      "artist": "Thundercat",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/17311ac4702bbc6245e9ee2958630c8f.jpg#17311ac4702bbc6245e9ee2958630c8f",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 8,
+      "title": "Special",
+      "artist": "Lizzo",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/aa0fa19a3c3cdff70672d238c9861358.jpg#aa0fa19a3c3cdff70672d238c9861358",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 9,
+      "title": "Schvitz",
+      "artist": "Vulfpeck",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/ba61a9b60778fb9ed2e8c209f19055d1.jpg#ba61a9b60778fb9ed2e8c209f19055d1",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 10,
+      "title": "Back to Black",
+      "artist": "Amy Winehouse",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/bc4e31504f5f47adb31f36aa0889be45.jpg#bc4e31504f5f47adb31f36aa0889be45",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 11,
+      "title": "Breaking the Balls of History",
+      "artist": "Quasi",
+      "image": "https://lastfm.freetls.fastly.net/i/u/60x60/2f113cd61ef5fea9730d49692c254b84.jpg",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 12,
+      "title": "An Innocent Man",
+      "artist": "Billy Joel",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/a12d150c799c416daef11949670485c8.jpg#a12d150c799c416daef11949670485c8",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 13,
+      "title": "Waking Up",
+      "artist": "OneRepublic",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/b243e3b226cf4b3089e166f30e2cb83c.jpg#b243e3b226cf4b3089e166f30e2cb83c",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 14,
+      "title": "Frontiers",
+      "artist": "Journey",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/a3bd61d82f22400abe781387166e7aa3.jpg#a3bd61d82f22400abe781387166e7aa3",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 15,
+      "title": "Honky Chateau",
+      "artist": "Elton John",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/600850c3207f8a27ff77e49d91f78c1b.jpg#600850c3207f8a27ff77e49d91f78c1b",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 16,
+      "title": "Abbey Road",
+      "artist": "The Beatles",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/af251669a48a4bafb448e1f6c0de01be.jpg#af251669a48a4bafb448e1f6c0de01be",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 17,
+      "title": "Toys in the Attic",
+      "artist": "Aerosmith",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/f9e9632ca1da6116f2b6e5f70ae9e7df.jpg#f9e9632ca1da6116f2b6e5f70ae9e7df",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 18,
+      "title": "Reggatta de Blanc",
+      "artist": "The Police",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/8135a6fa56f78744a678c5a0468417f0.jpg#8135a6fa56f78744a678c5a0468417f0",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 19,
+      "title": "Face Value",
+      "artist": "Phil Collins",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/565a36701b2ce857c1a581a769ceee62.jpg#565a36701b2ce857c1a581a769ceee62",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 20,
+      "title": "Thriller",
+      "artist": "Michael Jackson",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/e5f40ae3767cf5b6184776f97e52b8ca.jpg#e5f40ae3767cf5b6184776f97e52b8ca",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 21,
+      "title": "Worlds",
+      "artist": "Porter Robinson",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/599473f366dc4753c7ed0ed64f23df83.jpg#599473f366dc4753c7ed0ed64f23df83",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 22,
+      "title": "WLFGRL",
+      "artist": "Machine Girl",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/79d173d6a9926477816cea31d409a2d6.jpg#79d173d6a9926477816cea31d409a2d6",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 23,
+      "title": "Windswept Adan",
+      "artist": "Ichiko Aoba",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/3a39fc6acd5c9eb5f5c2ac532c8d69fa.jpg#3a39fc6acd5c9eb5f5c2ac532c8d69fa",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 24,
+      "title": "No New World",
+      "artist": "MASS OF THE FERMENTING DREGS",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/088fea2b4baa6f4ee55d9925a4aa9d8f.jpg#088fea2b4baa6f4ee55d9925a4aa9d8f",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 25,
+      "title": "Substance",
+      "artist": "New Order",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/a50955c73be3cb3b0a644d615c06290d.jpg#a50955c73be3cb3b0a644d615c06290d",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 26,
+      "title": "Boston",
+      "artist": "Boston",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/c88c27c1882542ae880ac063af38d647.jpg#c88c27c1882542ae880ac063af38d647",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 27,
+      "title": "Beatopia",
+      "artist": "beabadoobee",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/d47d0db3893fa94639514a2aa47372b8.jpg#d47d0db3893fa94639514a2aa47372b8",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 28,
+      "title": "Twilight",
+      "artist": "bôa",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/40564dd1a58f969fc3ee3c49bddffd23.jpg#40564dd1a58f969fc3ee3c49bddffd23",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 29,
+      "title": "Mercurial World",
+      "artist": "Magdalena Bay",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/c1b18f7dd5f2b262a96288bfa2330ad2.jpg#c1b18f7dd5f2b262a96288bfa2330ad2",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 30,
+      "title": "Kodama",
+      "artist": "Alcest",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/460454629c39c9890fe8af5870260675.jpg#460454629c39c9890fe8af5870260675",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 31,
+      "title": "Is There Anybody Out There?",
+      "artist": "A Great Big World",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/6f0e3a2d54b943f8c356977218f89520.jpg#6f0e3a2d54b943f8c356977218f89520",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 32,
+      "title": "Forget the World",
+      "artist": "Afrojack",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/de12f907fdbb42b1c232cc56c600c6c3.jpg#de12f907fdbb42b1c232cc56c600c6c3",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 33,
+      "title": "Best Day Ever",
+      "artist": "Mac Miller",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/98b0f62da13145c9a27102abf874f07e.jpg#98b0f62da13145c9a27102abf874f07e",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 34,
+      "title": "Dizzy Up the Girl",
+      "artist": "The Goo Goo Dolls",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/b5637551f8256bd31d895ad9db01d5d0.jpg#b5637551f8256bd31d895ad9db01d5d0",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 35,
+      "title": "Living Proof",
+      "artist": "State Champs",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/ff78ad66e21a26922e7288c860386acc.jpg#ff78ad66e21a26922e7288c860386acc",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 36,
+      "title": "Stories",
+      "artist": "Avicii",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/719ec212f89411b93ce528283ea8c007.jpg#719ec212f89411b93ce528283ea8c007",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 37,
+      "title": "the highs.",
+      "artist": "mike.",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/4ced1d846cfe63891fd638642e590965.jpg#4ced1d846cfe63891fd638642e590965",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 38,
+      "title": "Blacc Hollywood",
+      "artist": "Wiz Khalifa",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/59f3420cebb24680c6f4abb41b002599.jpg#59f3420cebb24680c6f4abb41b002599",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 39,
+      "title": "Brothers in Arms",
+      "artist": "Dire Straits",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/d3394952d369468ec64a7d5582c013cc.jpg#d3394952d369468ec64a7d5582c013cc",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  },
+  {
+      "id": 40,
+      "title": "Come Back Road",
+      "artist": "Logan Mize",
+      "image": "https://lastfm.freetls.fastly.net/i/u/770x0/5b9176350456f44bc34953f3e17d8a1b.jpg#5b9176350456f44bc34953f3e17d8a1b",
+      "favorite": false,
+      "created_at": "2023-02-27T22:05:11.321Z",
+      "updated_at": "2023-02-27T22:05:11.321Z"
+  }
+]

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "cypress": "cypress open"
   },
   "eslintConfig": {
     "extends": [
@@ -35,5 +36,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cypress": "^12.7.0"
   }
 }

--- a/src/AlbumTile/AlbumTile.jsx
+++ b/src/AlbumTile/AlbumTile.jsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom'
 import PropTypes from "prop-types";
 
 const AlbumTile = ({album}) => {
-    console.log(album)
     return (
       <div className="album-tile">
         <Link to={{

--- a/src/AlbumTile/AlbumTile.jsx
+++ b/src/AlbumTile/AlbumTile.jsx
@@ -1,5 +1,6 @@
 import './AlbumTile.css'
 import { Link } from 'react-router-dom'
+import PropTypes from "prop-types";
 
 const AlbumTile = ({album}) => {
     console.log(album)
@@ -19,3 +20,15 @@ const AlbumTile = ({album}) => {
   }
   
   export default AlbumTile
+
+  AlbumTile.propTypes = {
+    album: PropTypes.shape({
+        artist: PropTypes.string.isRequired,
+        createdAt: PropTypes.string.isRequired,
+        favorite: PropTypes.bool.isRequired,
+        id: PropTypes.number.isRequired,
+        image: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        updatedAt: PropTypes.string.isRequired
+    }).isRequired
+  }

--- a/src/AlbumsView/AlbumsView.jsx
+++ b/src/AlbumsView/AlbumsView.jsx
@@ -6,11 +6,17 @@ import AlbumTile from '../AlbumTile/AlbumTile'
 function AlbumsView() {
     const [albums, storeAlbums] = React.useState([])
     const [loading, setload] = React.useState(true)
+    const [error, setError] = React.useState('')
 
     const retrieveAlbums = () => {
         getAlbums()
         .then(data => {
             storeAlbums(data)
+            setload(false)
+        })
+        .catch(err => {
+            setError(err)
+            setload(false)
         })
     }
 
@@ -20,13 +26,13 @@ function AlbumsView() {
 
     return (
       <div className="albums-view">
-        {/* {(loading) && <p>Loading...</p>} */}
+        {(loading) && <p>Loading...</p>}
         {(albums) && albums.map((album, index) => {
             return (
                 <AlbumTile album={album} key={index} />
             )
         })}
-
+        {(error) && <p>An error occured please try again later.</p>}  
       </div>
     )
   }

--- a/src/Utilities/APICalls.jsx
+++ b/src/Utilities/APICalls.jsx
@@ -1,11 +1,11 @@
 export const getAlbums = () => {
     return (
-        fetch('http://localhost:3000/albums')
+        fetch('https://tune-spoon-db-v1.herokuapp.com/albums')
         .then(response => {
             if (response.ok) {
                 return response.json()
             } else {
-                throw new Error()
+                throw new Error('Something went wrong')
             }
         })
     )


### PR DESCRIPTION
This PR adds

- homepage and header cypress testing
- proptypes to AlbumTile.jsx
- adds loading and error display to AlbumView.jsx
- changes the api call to local host to use https://tune-spoon-db-v1.herokuapp.com/albums